### PR TITLE
Fix: python env source

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deploy `/contracts/tokens/ERC721.cairo` to StarkNet to have the NFTs available f
 
 ```
 python3 -m venv env
-source env/bin/active
+source env/bin/activate
 pip install git+https://github.com/OpenZeppelin/nile.git
 nile install
 ```


### PR DESCRIPTION
## Fix

Change `source env/bin/active` to `source env/bin/activate`.

Creating a virtual environment with python creates a script called `activate`.